### PR TITLE
Tip 1: Give nested resources a dedicated controller

### DIFF
--- a/app/Http/Controllers/EpisodesController.php
+++ b/app/Http/Controllers/EpisodesController.php
@@ -27,32 +27,6 @@ class EpisodesController extends Controller
         ]);
     }
 
-    public function create($id)
-    {
-        $podcast = Auth::user()->podcasts()->findOrFail($id);
-
-        return view('episodes.create', ['podcast' => $podcast]);
-    }
-
-    public function store($id)
-    {
-        $podcast = Auth::user()->podcasts()->findOrFail($id);
-
-        request()->validate([
-            'title' => ['required', 'max:150'],
-            'description' => ['max:500'],
-            'download_url' => ['required', 'url'],
-        ]);
-
-        $episode = $podcast->episodes()->create(request([
-            'title',
-            'description',
-            'download_url',
-        ]));
-
-        return redirect("/episodes/{$episode->id}");
-    }
-
     public function edit($id)
     {
         $episode = Episode::with('podcast')->findOrFail($id);

--- a/app/Http/Controllers/PodcastEpisodesController.php
+++ b/app/Http/Controllers/PodcastEpisodesController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Podcast;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class PodcastEpisodesController extends Controller
+{
+    public function index($id)
+    {
+        $podcast = Podcast::with('episodes')->findOrFail($id);
+
+        abort_unless($podcast->isVisibleTo(Auth::user()), 404);
+
+        return view('podcast-episodes.index', [
+            'podcast' => $podcast,
+        ]);
+    }
+
+    public function create($id)
+    {
+        $podcast = Auth::user()->podcasts()->findOrFail($id);
+
+        return view('podcast-episodes.create', ['podcast' => $podcast]);
+    }
+
+    public function store($id)
+    {
+        $podcast = Auth::user()->podcasts()->findOrFail($id);
+
+        request()->validate([
+            'title' => ['required', 'max:150'],
+            'description' => ['max:500'],
+            'download_url' => ['required', 'url'],
+        ]);
+
+        $episode = $podcast->episodes()->create(request([
+            'title',
+            'description',
+            'download_url',
+        ]));
+
+        return redirect("/episodes/{$episode->id}");
+    }
+}

--- a/app/Http/Controllers/PodcastsController.php
+++ b/app/Http/Controllers/PodcastsController.php
@@ -89,17 +89,6 @@ class PodcastsController extends Controller
         return redirect("/podcasts");
     }
 
-    public function listEpisodes($id)
-    {
-        $podcast = Podcast::with('episodes')->findOrFail($id);
-
-        abort_unless($podcast->isVisibleTo(Auth::user()), 404);
-
-        return view('podcasts.list-episodes', [
-            'podcast' => $podcast,
-        ]);
-    }
-
     public function updateCoverImage($id)
     {
         $podcast = Auth::user()->podcasts()->findOrFail($id);

--- a/resources/views/podcast-episodes/index.blade.php
+++ b/resources/views/podcast-episodes/index.blade.php
@@ -33,7 +33,11 @@
                         </div>
                     </div>
                     <div class="mb-4">
-                        <subscribe-button :data-podcast="{{ $podcast }}"></subscribe-button>
+                        <subscribe-button
+                            subscribe-url="{{ action('PodcastsController@subscribe', $podcast) }}"
+                            unsubscribe-url="{{ action('PodcastsController@unsubscribe', $podcast) }}"
+                            :data-subscribed="{{ json_encode(Auth::user()->subscribesTo($podcast)) }}"
+                        ></subscribe-button>
                     </div>
                     <p class="text-dark-soft">{{ $podcast->description }}</p>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,6 @@ Route::get('/podcasts/{id}',                        'PodcastsController@show');
 Route::get('/podcasts/{id}/edit',                   'PodcastsController@edit');
 Route::patch('/podcasts/{id}',                      'PodcastsController@update');
 Route::delete('/podcasts/{id}',                     'PodcastsController@destroy');
-Route::get('/podcasts/{id}/episodes',               'PodcastsController@listEpisodes');
 Route::post('/podcasts/{id}/update-cover-image',    'PodcastsController@updateCoverImage');
 Route::post('/podcasts/{id}/subscribe',             'PodcastsController@subscribe');
 Route::post('/podcasts/{id}/unsubscribe',           'PodcastsController@unsubscribe');
@@ -31,7 +30,9 @@ Route::post('/podcasts/{id}/unpublish',             'PodcastsController@unpublis
 
 Route::get('/episodes',                             'EpisodesController@index');
 Route::get('/episodes/{id}',                        'EpisodesController@show');
-Route::get('/podcasts/{id}/episodes/new',           'EpisodesController@create');
-Route::post('/podcasts/{id}/episodes',              'EpisodesController@store');
 Route::get('/episodes/{id}/edit',                   'EpisodesController@edit');
 Route::patch('/episodes/{id}',                      'EpisodesController@update');
+
+Route::get('/podcasts/{id}/episodes',               'PodcastEpisodesController@index');
+Route::post('/podcasts/{id}/episodes',              'PodcastEpisodesController@store');
+Route::get('/podcasts/{id}/episodes/new',           'PodcastEpisodesController@create');


### PR DESCRIPTION
When dealing with nested resources in an application, you often end up with routes like this:

```
/podcasts/{id}/episodes
```

When you have an endpoint like this, which controller do you use and what do you call the action?

### ❌ Option 1: PodcastsController

Since `/podcasts` is the top level resource, it's common to use the `PodcastsController` for these sorts of nested index actions.

This can work but it forces you to define a "custom action"; something that isn't part of the 7 standard REST/CRUD actions that exist on a resource controller.

In this example, we started with an action on `PodcastsController` called `listEpisodes`. If we want to stick to only the 7 standard controller actions, what else could we do?

### ❌ Option 2: EpisodesController 

Since this action is a list of episodes, you might think "hey, let's make this `EpisodesController@index`!"

But there's a problem: we already have an `EpisodesController@index` action! In our case, it lists all episodes across all podcasts.

#### Antipattern: Optional route parameters

One thing I've seen folks do in this case is re-use `EpisodesController@index` for two different use cases: listing all episodes *or* listing an individual podcast's episodes.

That usually looks like this in a routes file:

```php
Route::get('/episodes',               'EpisodesController@index');
Route::get('/podcasts/{id}/episodes', 'EpisodesController@index');
```

...and like this in the controller:

```php
class EpisodesController
{
    public function index($id = null)
    {
        if ($id === null) {
            $episodes = Episode::with('podcast')->recent()->paginate(25);

            return view('episodes.index', [
                'episodes' => $episodes,
            ]);
        } else {

            $podcast = Podcast::with('episodes')->findOrFail($id);

            abort_unless($podcast->isVisibleTo(Auth::user()), 404);

            return view('podcasts.list-episodes', [
                'podcast' => $podcast,
            ]);
        }
    }
}
```

The problem with this approach is that you are taking two completely different actions from the user's point of view and stuffing them all into one action that has to reverse-engineer the intent of the user based on the presence of the route parameter.

These actions have literally nothing in common:

- Load different models
- Have different permission checks
- Return different views
- Pass different data to the views

If our goal is to use more controllers to simplify our code, this isn't helping. We actually have one less controller action than before, resulting in another controller action getting much more complicated.

*Don't reuse a single controller action for two different user actions.*


### ✅ Option 3: Dedicated PodcastEpisodesController

If we want to stick to only standard actions, that means we want to use an `index` action here. But what is the resource we are requesting an `index` of?

You could say it's `episodes`, but we're not requesting an index of *all* episodes. It's a specific *podcast's* episodes, so you could say we want an index of "podcast episodes".

If we create a brand new controller for this, here's what our route definition would look like:

```php
Route::get('/podcasts/{id}/episodes', 'PodcastEpisodesController@index');
```

...and here's the controller with it's action:

```php
class PodcastEpisodesController extends Controller
{
    public function index($id)
    {
        $podcast = Podcast::with('episodes')->findOrFail($id);

        abort_unless($podcast->isVisibleTo(Auth::user()), 404);

        return view('podcast-episodes.index', [
            'podcast' => $podcast,
        ]);
    }
}
```

When taking this approach, I usually make my template folder structure match the controller name, as you can see above with the `podcast-episodes.index` view.

#### Side benefit: Attracting existing nested resource endpoints

If you look in the routes file, you'll see we have two other `episodes` related endpoints nested under the top-level `podcasts` resource:

```php
Route::get('/podcasts/{id}/episodes/new', 'EpisodesController@create');
Route::post('/podcasts/{id}/episodes',    'EpisodesController@store');
```

This isn't bad on it's own, but it's sort of awkward that inside of `EpisodesController`, the `$id` route parameter has multiple meanings.

For example, here it represents an `Episode` ID:

```php
public function show($id)
{
    $episode = Episode::with('podcast')->findOrFail($id);

    abort_unless($episode->isVisibleTo(Auth::user()), 404);

    return view('episodes.show', [
        'episode' => $episode,
    ]);
}
```

...but in our `create` action, it represents a `Podcast` ID:

```php
public function create($id)
{
    $podcast = Auth::user()->podcasts()->findOrFail($id);

    return view('episodes.create', ['podcast' => $podcast]);
}
```

To me this is a bit of a smell.

*Each controller should only be concerned about the ID of one type of resource.*

Now that we have a dedicated `PodcastEpisodesController`, we can move our `create` and `store` actions alongside our new `index` action, and now the `$id` parameter will always refer to a `Podcast` ID:

```php
Route::get('/podcasts/{id}/episodes',     'PodcastEpisodesController@index');
Route::post('/podcasts/{id}/episodes',    'PodcastEpisodesController@store');
Route::get('/podcasts/{id}/episodes/new', 'PodcastEpisodesController@create');
```

After this refactoring, we're left with 3 controllers:

- `PodcastsController`, with 7 standard actions and 5 custom actions
- `EpisodesController`, with 4 standard actions and no custom actions
- `PodcastEpisodesController`, with 3 standard actions and no custom actions

**Next up: [Treat properties that are edited independently like a separate resource](https://github.com/adamwathan/laracon2017/pull/2)**

