### PR TITLE
Remove loginUsingId from boot method

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,9 +13,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if (! app()->environment('testing')) {
-            auth()->loginUsingId(2);
-        }
+        //
     }
 
     /**


### PR DESCRIPTION
Removing 

```
        if (! app()->environment('testing')) {
            auth()->loginUsingId(2);
        }
```

... This just throws a SQL error from a fresh install. Connection refused (SQL: select * from `users` where `id` = 2 limit 1). Since it's in the AppServiceProvider, composer install / update will fail since laravel 5.5 attempts to run a php artisan command.

Maybe there is a better way?