### PR TITLE
Update increments to unsignedInteger

### DIFF
--- a/database/migrations/2017_08_02_201156_create_subscriptions_table.php
+++ b/database/migrations/2017_08_02_201156_create_subscriptions_table.php
@@ -15,8 +15,8 @@ class CreateSubscriptionsTable extends Migration
     {
         Schema::create('subscriptions', function (Blueprint $table) {
             $table->increments('id');
-            $table->increments('user_id');
-            $table->increments('podcast_id');
+            $table->unsignedInteger('user_id');
+            $table->unsignedInteger('podcast_id');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
When using Postgres 9.6.3, I was getting the following error

Invalid table definition: 7 ERROR:  multiple primary keys for table "subscriptions" are not allowed at character 82.

By switching the table to not use increments, the migrations work as expected.